### PR TITLE
Clean up rubocop warnings and enforce on Travis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Include:
     - 'Gemfile'
     - 'Rakefile'
+    - 'guides-style-mbland.gemspec'
 
 Lint/ParenthesesAsGroupedExpression:
   Description: Checks for method calls with a space before the opening parenthesis.
@@ -50,7 +51,7 @@ Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
@@ -59,8 +60,11 @@ Style/DotPosition:
   - leading
   - trailing
 
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Description: Do not use unnecessary spacing.
+  Enabled: false
+
+Layout/IndentHeredoc:
   Enabled: false
 
 Style/GuardClause:
@@ -78,13 +82,13 @@ Style/StringLiterals:
   - single_quotes
   - double_quotes
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Description:
     Not allowing a comma after the last item in a list or hash when each item
     is on a single line is a bug, not a feature.
   EnforcedStyleForMultiline: comma
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Description:
     When aligning parameters is not appropriate due to line-length
     constraints, single indent for the lines after the first is also
@@ -92,7 +96,7 @@ Style/AlignParameters:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
   EnforcedStyle: with_fixed_indentation
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Description:
     Allow indented multiline operations, rather than strict alignment.
   EnforcedStyle: indented

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 rvm:
 - 2.4
 cache: bundler
-script: bundle exec rake test build
+script: bundle exec rubocop && bundle exec rake test build

--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ add the following (you may need to remove any `layout:`
 this to take effect):
 
 ```yaml
+theme: guides_style_mbland
+
 defaults:
   -
     scope:
       path: ""
     values:
-      layout: "guides_style_mbland_default"
+      layout: "default"
 ```
 
 Build the site per usual, and observe the results.

--- a/guides-style-mbland.gemspec
+++ b/guides-style-mbland.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'guides_style_mbland/version'
@@ -9,11 +8,10 @@ Gem::Specification.new do |s|
   s.authors       = ['Mike Bland']
   s.email         = ['mbland@acm.org']
   s.summary       = 'Guides style elements for Jekyll'
-  s.description   = (
+  s.description   = \
     'Provides consistent style elements for Guides generated using Jekyll. ' \
     'Originally based on DOCter (https://github.com/cfpb/docter/) ' \
     'from CFPB (http://cfpb.github.io/).'
-  )
   s.homepage      = 'https://github.com/mbland/guides-style-mbland'
   s.license       = 'ISC'
 

--- a/lib/guides_style_mbland/generated_nodes.rb
+++ b/lib/guides_style_mbland/generated_nodes.rb
@@ -39,7 +39,8 @@ module GuidesStyleMbland
     end
 
     def self.generated_node(parent_slug)
-      { 'text' => parent_slug.split('-').join(' ').capitalize,
+      {
+        'text' => parent_slug.split('-').join(' ').capitalize,
         'url' => parent_slug + '/',
         'internal' => true,
         'generated' => true,

--- a/lib/guides_style_mbland/generated_pages.rb
+++ b/lib/guides_style_mbland/generated_pages.rb
@@ -1,6 +1,6 @@
 module GuidesStyleMbland
   class GeneratedPages
-    DEFAULT_LAYOUT = 'guides_style_mbland_generated_home_redirect'
+    DEFAULT_LAYOUT = 'guides_style_mbland_generated_home_redirect'.freeze
 
     def self.generate_pages_from_navigation_data(site)
       layout = site.config['generate_nodes']
@@ -10,8 +10,8 @@ module GuidesStyleMbland
       generate_pages_from_generated_nodes(site, layout, nav_data, '/')
     end
 
-    def self.generate_pages_from_generated_nodes(
-      site, layout, nav_data, parent_url)
+    def self.generate_pages_from_generated_nodes(site, layout, nav_data,
+      parent_url)
       (nav_data || []).select { |nav| nav['generated'] }.each do |nav|
         site.pages << GeneratedPage.new(site, layout, nav, parent_url)
         children = nav['children']

--- a/lib/guides_style_mbland/namespace_flattener.rb
+++ b/lib/guides_style_mbland/namespace_flattener.rb
@@ -32,8 +32,8 @@ module GuidesStyleMbland
       return if collisions.empty?
 
       messages = collisions.map { |flat, orig| "#{flat}: #{orig.join(', ')}" }
-      fail(StandardError, "collisions in flattened namespace between\n  " +
-        messages.join("\n  "))
+      raise StandardError, "collisions in flattened namespace between\n  " +
+        messages.join("\n  ")
     end
   end
 end

--- a/lib/guides_style_mbland/repository.rb
+++ b/lib/guides_style_mbland/repository.rb
@@ -2,7 +2,7 @@ require 'English'
 require 'fileutils'
 
 module GuidesStyleMbland
-  TEMPLATE_FILES = %w(
+  TEMPLATE_FILES = %w[
     _pages/add-a-new-page/make-a-child-page.md
     _pages/add-a-new-page.md
     _pages/add-images.md
@@ -18,10 +18,10 @@ module GuidesStyleMbland
     images/gh-default-branch.png
     images/gh-settings-button.png
     images/gh-webhook.png
-  )
+  ].freeze
 
-  def self.clear_template_files_and_create_new_repository(
-    basedir, outstream = $stdout)
+  def self.clear_template_files_and_create_new_repository(basedir,
+    outstream = $stdout)
     remove_template_files basedir, outstream
     delete_create_repo_command_from_go_script basedir, outstream
     create_new_git_repository basedir, outstream
@@ -31,7 +31,7 @@ module GuidesStyleMbland
     Dir.chdir basedir do
       outstream.puts 'Clearing Guides Template files.'
       files = TEMPLATE_FILES.map { |f| File.join basedir, f }
-        .select { |f| File.exist? f }
+                            .select { |f| File.exist? f }
       File.delete(*files)
     end
   end
@@ -51,7 +51,7 @@ module GuidesStyleMbland
     'Creating a new git repository.' => 'git init',
     'Creating mbland-pages branch.' => 'git checkout -b mbland-pages',
     'Adding files for initial commit.' => 'git add .',
-  }
+  }.freeze
 
   def self.create_new_git_repository(basedir, outstream)
     Dir.chdir basedir do

--- a/lib/guides_style_mbland/tags.rb
+++ b/lib/guides_style_mbland/tags.rb
@@ -3,7 +3,7 @@ require 'liquid'
 
 module GuidesStyleMbland
   class ShouldExpandNavTag < ::Liquid::Tag
-    NAME = 'guides_style_mbland_should_expand_nav'
+    NAME = 'guides_style_mbland_should_expand_nav'.freeze
     ::Liquid::Template.register_tag(NAME, self)
 
     attr_reader :parent_reference, :url_reference
@@ -32,7 +32,7 @@ module GuidesStyleMbland
   end
 
   class PopLastUrlComponent < ::Liquid::Tag
-    NAME = 'guides_style_mbland_pop_last_url_component'
+    NAME = 'guides_style_mbland_pop_last_url_component'.freeze
     ::Liquid::Template.register_tag(NAME, self)
 
     attr_reader :reference

--- a/lib/guides_style_mbland/update.rb
+++ b/lib/guides_style_mbland/update.rb
@@ -1,6 +1,6 @@
 module GuidesStyleMbland
   def self.update_theme
     exec({ 'RUBYOPT' => nil }, 'bundle',
-      *%w(update --source guides_style_mbland))
+      *%w[update --source guides_style_mbland].freeze)
   end
 end

--- a/lib/guides_style_mbland/version.rb
+++ b/lib/guides_style_mbland/version.rb
@@ -1,3 +1,3 @@
 module GuidesStyleMbland
-  VERSION = '0.1.0'
+  VERSION = '0.1.0'.freeze
 end

--- a/test/breadcrumbs_test.rb
+++ b/test/breadcrumbs_test.rb
@@ -44,17 +44,20 @@ module GuidesStyleMbland
     def test_nav_items_with_children
       site.config['navigation'] = [
         { 'text' => 'Introduction' },
-        { 'url' => 'foo/',
+        {
+          'url' => 'foo/',
           'text' => 'Foo info',
           'children' => [
             { 'url' => 'bar/', 'text' => 'Bar info' },
             { 'url' => 'baz/', 'text' => 'Baz info' },
           ],
         },
-        { 'url' => 'quux/',
+        {
+          'url' => 'quux/',
           'text' => 'Quux info',
           'children' => [
-            { 'url' => 'xyzzy/',
+            {
+              'url' => 'xyzzy/',
               'text' => 'Xyzzy info',
               'children' => [
                 { 'url' => 'plugh/', 'text' => 'Plugh info' },

--- a/test/flatten_url_namespace_test.rb
+++ b/test/flatten_url_namespace_test.rb
@@ -39,17 +39,20 @@ module GuidesStyleMbland
     def setup_nav
       site.config['navigation'] = [
         { 'text' => 'Introduction' },
-        { 'url' => 'foo/',
+        {
+          'url' => 'foo/',
           'text' => 'Foo info',
           'children' => [
             { 'url' => 'bar/', 'text' => 'Bar info' },
             { 'url' => 'baz/', 'text' => 'Baz info' },
           ],
         },
-        { 'url' => 'quux/',
+        {
+          'url' => 'quux/',
           'text' => 'Quux info',
           'children' => [
-            { 'url' => 'xyzzy/',
+            {
+              'url' => 'xyzzy/',
               'text' => 'Xyzzy info',
               'children' => [
                 { 'url' => 'plugh/', 'text' => 'Plugh info' },
@@ -114,45 +117,24 @@ module GuidesStyleMbland
       assert_equal('/quux/xyzzy/', xyzzy_page.data['permalink'])
       assert_equal('/quux/xyzzy/plugh/', plugh_page.data['permalink'])
 
-      assert_equal(
-        [
-          { 'url' => '/', 'text' => 'Introduction' },
-        ],
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' }],
         foo_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-          { 'url' => '/foo/bar/', 'text' => 'Bar info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' },
+                    { 'url' => '/foo/bar/', 'text' => 'Bar info' }],
         bar_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-          { 'url' => '/foo/baz/', 'text' => 'Baz info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' },
+                    { 'url' => '/foo/baz/', 'text' => 'Baz info' }],
         baz_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' }],
         quux_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' },
+                    { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' }],
         xyzzy_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
-          { 'url' => '/quux/xyzzy/plugh/', 'text' => 'Plugh info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' },
+                    { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
+                    { 'url' => '/quux/xyzzy/plugh/', 'text' => 'Plugh info' }],
         plugh_page.data['breadcrumbs'])
     end
 
@@ -169,45 +151,24 @@ module GuidesStyleMbland
       assert_equal('/xyzzy/', xyzzy_page.data['permalink'])
       assert_equal('/plugh/', plugh_page.data['permalink'])
 
-      assert_equal(
-        [
-          { 'url' => '/', 'text' => 'Introduction' },
-        ],
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' }],
         foo_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-          { 'url' => '/bar/', 'text' => 'Bar info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' },
+                    { 'url' => '/bar/', 'text' => 'Bar info' }],
         bar_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/foo/', 'text' => 'Foo info' },
-          { 'url' => '/baz/', 'text' => 'Baz info' },
-        ],
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' },
+                    { 'url' => '/baz/', 'text' => 'Baz info' }],
         baz_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' }],
         quux_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-          { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' },
+                    { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' }],
         xyzzy_page.data['breadcrumbs'])
-      assert_equal(
-        [
-          { 'url' => '/quux/', 'text' => 'Quux info' },
-          { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' },
-          { 'url' => '/plugh/', 'text' => 'Plugh info' },
-        ],
+      assert_equal([{ 'url' => '/quux/', 'text' => 'Quux info' },
+                    { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' },
+                    { 'url' => '/plugh/', 'text' => 'Plugh info' }],
         plugh_page.data['breadcrumbs'])
     end
 

--- a/test/generated_nodes_test.rb
+++ b/test/generated_nodes_test.rb
@@ -7,8 +7,7 @@ module GuidesStyleMbland
   # rubocop:disable ClassLength
   # rubocop:disable MethodLength
   class GeneratedNodesTest < ::Minitest::Test
-    def setup
-    end
+    def setup; end
 
     def generate_url_map(nav_data)
       NavigationMenu.map_nav_items_by_url('/', nav_data).to_h
@@ -45,12 +44,11 @@ module GuidesStyleMbland
       url_to_nav = generate_url_map(nav_data)
       GeneratedNodes.create_homes_for_orphans(url_to_nav, nav_data)
       assert_equal(
-        [page_nav(
-          'foo/', 'Foo',
+        [page_nav('foo/', 'Foo',
           generated: true,
-          children: [page_nav('bar/', 'Bar info')])
-        ],
-        nav_data)
+          children: [page_nav('bar/', 'Bar info')])],
+        nav_data
+      )
     end
 
     def test_multiple_orphans
@@ -62,16 +60,17 @@ module GuidesStyleMbland
       url_to_nav = generate_url_map(nav_data)
       GeneratedNodes.create_homes_for_orphans(url_to_nav, nav_data)
       assert_equal(
-        [page_nav(
-          'foo/', 'Foo',
-          generated: true,
-          children: [
-            page_nav('bar/', 'Bar info'),
-            page_nav('baz/', 'Baz info'),
-            page_nav('quux/', 'Quux info'),
-          ])
+        [
+          page_nav('foo/', 'Foo',
+            generated: true,
+            children: [
+              page_nav('bar/', 'Bar info'),
+              page_nav('baz/', 'Baz info'),
+              page_nav('quux/', 'Quux info'),
+            ]),
         ],
-        nav_data)
+        nav_data
+      )
     end
 
     def test_nested_orphan
@@ -79,44 +78,40 @@ module GuidesStyleMbland
       url_to_nav = generate_url_map(nav_data)
       GeneratedNodes.create_homes_for_orphans(url_to_nav, nav_data)
       assert_equal(
-        [page_nav(
-          'foo/', 'Foo',
-          generated: true,
-          children: [
-            page_nav(
-              'bar/', 'Bar',
-              generated: true,
-              children: [page_nav('baz/', 'Baz info')])
-          ])
+        [
+          page_nav('foo/', 'Foo',
+            generated: true,
+            children: [
+              page_nav('bar/', 'Bar',
+                generated: true,
+                children: [page_nav('baz/', 'Baz info')]),
+            ]),
         ],
-        nav_data)
+        nav_data
+      )
     end
 
     def test_remove_stale_nav_entries_does_not_remove_generated_parent_nodes
       nav_data = [
-        page_nav(
-          'foo/', 'Foo',
+        page_nav('foo/', 'Foo',
           generated: true,
           children: [
-            page_nav(
-              'bar/', 'Bar',
+            page_nav('bar/', 'Bar',
               generated: true,
-              children: [page_nav('baz/', 'Baz info')])
-          ])
+              children: [page_nav('baz/', 'Baz info')]),
+          ]),
       ]
       url_to_nav = generate_url_map(nav_data)
-      updated = { '/foo/bar/baz/': true }
-      refute_empty(
-        NavigationMenu.remove_stale_nav_entries(nav_data, url_to_nav, updated))
+      updated = { '/foo/bar/baz/' => true }
+      refute_empty(NavigationMenu.remove_stale_nav_entries(nav_data,
+        url_to_nav, updated))
     end
 
     def test_childless_parent_nodes_are_pruned
       nav_data = [
-        page_nav(
-          'foo/', 'Foo',
+        page_nav('foo/', 'Foo',
           generated: true,
-          children: [page_nav('bar/', 'Bar', generated: true)]
-        )
+          children: [page_nav('bar/', 'Bar', generated: true)]),
       ]
 
       url_to_nav = generate_url_map(nav_data)
@@ -132,29 +127,27 @@ module GuidesStyleMbland
       url_to_nav = generate_url_map(nav_data)
       GeneratedNodes.create_homes_for_orphans(url_to_nav, nav_data)
       assert_equal(
-        [page_nav(
-          'foo/', 'Foo',
-          generated: true,
-          children: [
-            page_nav(
-              'bar/', 'Bar info',
-              children: [page_nav('baz/', 'Baz info')])
-          ])
+        [
+          page_nav('foo/', 'Foo',
+            generated: true,
+            children: [
+              page_nav('bar/', 'Bar info',
+                children: [page_nav('baz/', 'Baz info')]),
+            ]),
         ],
-        nav_data)
+        nav_data
+      )
     end
 
     def test_replace_existing_generated_node_with_new_page_node
       nav_data = [
-        page_nav(
-          'foo/', 'Foo',
+        page_nav('foo/', 'Foo',
           generated: true,
           children: [
-            page_nav(
-              'bar/', 'Bar',
+            page_nav('bar/', 'Bar',
               generated: true,
-              children: [page_nav('baz/', 'Baz info')])
-          ])
+              children: [page_nav('baz/', 'Baz info')]),
+          ]),
       ]
       url_to_nav = generate_url_map(nav_data)
       updated = {
@@ -170,16 +163,15 @@ module GuidesStyleMbland
       GeneratedNodes.create_homes_for_orphans(url_to_nav, nav_data)
       assert_equal(
         [
-          page_nav(
-            'foo/', 'Foo info',
+          page_nav('foo/', 'Foo info',
             children: [
-              page_nav(
-                'bar/', 'Bar',
+              page_nav('bar/', 'Bar',
                 generated: true,
-                children: [page_nav('baz/', 'Baz info')])
-            ])
+                children: [page_nav('baz/', 'Baz info')]),
+            ]),
         ],
-        nav_data)
+        nav_data
+      )
     end
   end
   # rubocop:enable MethodLength

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -95,7 +95,7 @@ module GuidesStyleMbland
       assert_equal expected, read_config
     end
 
-    ALL_PAGES = %w(
+    ALL_PAGES = %w[
       add-a-new-page/make-a-child-page.md
       add-a-new-page.md
       add-images.md
@@ -104,7 +104,7 @@ module GuidesStyleMbland
       post-your-guide.md
       update-the-config-file/understanding-baseurl.md
       update-the-config-file.md
-    )
+    ].freeze
 
     def test_all_pages_with_existing_data
       write_config NAV_YAML
@@ -113,10 +113,10 @@ module GuidesStyleMbland
       assert_equal "#{COLLECTIONS_CONFIG}\n#{NAV_YAML}", read_config
     end
 
-    LEADING_COMMENT = '' \
-      '# Comments before the navigation section should be preserved.'
-    TRAILING_COMMENT = '' \
-      "# Comments after the navigation section should also be preserved.\n"
+    LEADING_COMMENT =  \
+      '# Comments before the navigation section should be preserved.'.freeze
+    TRAILING_COMMENT = '# Comments after the navigation section ' +
+      "should also be preserved.\n".freeze
 
     # We need to be careful not to modify the original NAV_DATA object when
     # sorting.
@@ -222,7 +222,7 @@ module GuidesStyleMbland
       expected_data = sorted_nav_data(NAV_DATA)
       expected_data['navigation'].unshift(
         'text' => 'Link to the mbland/guides-style-mbland repo',
-        'url' => 'https://github.com/mbland/guides-style-mbland',
+        'url' => 'https://github.com/mbland/guides-style-mbland'
       )
       assert_result_matches_expected_config(expected_data)
     end
@@ -317,7 +317,7 @@ module GuidesStyleMbland
 
     def test_should_raise_if_parent_page_does_not_exist
       write_config CONFIG_MISSING_PARENT_PAGE
-      copy_pages ALL_PAGES.reject { |page| page == 'add-a-new-page.md' }
+      copy_pages(ALL_PAGES.reject { |page| page == 'add-a-new-page.md' })
       exception = assert_raises(StandardError) do
         GuidesStyleMbland.update_navigation_configuration testdir
       end
@@ -342,14 +342,14 @@ module GuidesStyleMbland
       assert_result_matches_expected_config(NAV_DATA)
     end
 
-    NO_LEADING_SLASH = <<NO_LEADING_SLASH
+    NO_LEADING_SLASH = <<NO_LEADING_SLASH.freeze
 ---
 title: No leading slash
 permalink: no-leading-slash/
 ---
 NO_LEADING_SLASH
 
-    NO_TRAILING_SLASH = <<NO_TRAILING_SLASH
+    NO_TRAILING_SLASH = <<NO_TRAILING_SLASH.freeze
 ---
 title: No trailing slash
 permalink: /no-trailing-slash
@@ -360,9 +360,9 @@ NO_TRAILING_SLASH
       'missing-front-matter.md' => 'no front matter brosef',
       'no-leading-slash.md' => NO_LEADING_SLASH,
       'no-trailing-slash.md' => NO_TRAILING_SLASH,
-    }
+    }.freeze
 
-    EXPECTED_ERRORS = <<EXPECTED_ERRORS
+    EXPECTED_ERRORS = <<EXPECTED_ERRORS.freeze
 The following files have errors in their front matter:
   _pages/missing-front-matter.md:
     no front matter defined
@@ -380,7 +380,8 @@ EXPECTED_ERRORS
       write_config NAV_YAML
       FILES_WITH_ERRORS.each { |file, content| write_page file, content }
       errors = GuidesStyleMbland::FrontMatter.validate_with_message_upon_error(
-        GuidesStyleMbland::FrontMatter.load(testdir))
+        GuidesStyleMbland::FrontMatter.load(testdir)
+      )
       assert_equal EXPECTED_ERRORS, errors + "\n"
     end
 
@@ -388,11 +389,12 @@ EXPECTED_ERRORS
       write_config NAV_YAML
       write_page('image.png', '')
       errors = GuidesStyleMbland::FrontMatter.validate_with_message_upon_error(
-        GuidesStyleMbland::FrontMatter.load(testdir))
+        GuidesStyleMbland::FrontMatter.load(testdir)
+      )
       assert_nil(errors)
     end
 
-    WITH_NAVTITLE = <<WITH_NAVTITLE
+    WITH_NAVTITLE = <<WITH_NAVTITLE.freeze
 ---
 title: Some egregiously, pretentiously, criminally long title
 navtitle: Hello!
@@ -426,7 +428,8 @@ WITH_NAVTITLE
           GuidesStyleMbland.update_navigation_configuration testdir
         end
         assert_equal 1, exception.status
-        assert($stderr.string.include? EXPECTED_ERRORS + "_config.yml not updated\n")
+        assert($stderr.string.include?(EXPECTED_ERRORS +
+          "_config.yml not updated\n"))
       end
     end
   end

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -33,7 +33,7 @@ module GuidesStyleMbland
     end
 
     def nontemplate_files
-      @nontemplate_files ||= map_files_to_repo_dir %w(foo bar baz)
+      @nontemplate_files ||= map_files_to_repo_dir(%w[foo bar baz])
     end
 
     def write_all_files
@@ -43,7 +43,7 @@ module GuidesStyleMbland
       end
     end
 
-    GO_SCRIPT_BEFORE = <<GO_SCRIPT
+    GO_SCRIPT_BEFORE = <<GO_SCRIPT.freeze
 extend GoScript
 check_ruby_version '2.1.5'
 
@@ -64,7 +64,7 @@ end
 execute_command ARGV
 GO_SCRIPT
 
-    GO_SCRIPT_AFTER = <<GO_SCRIPT
+    GO_SCRIPT_AFTER = <<GO_SCRIPT.freeze
 extend GoScript
 check_ruby_version '2.1.5'
 
@@ -97,11 +97,14 @@ GO_SCRIPT
         GuidesStyleMbland.exec_cmd_capture_output 'git init', logfile
         GuidesStyleMbland.exec_cmd_capture_output 'git add .', logfile
         GuidesStyleMbland.exec_cmd_capture_output(
-          'git config user.email "test@example.com"', logfile)
+          'git config user.email "test@example.com"', logfile
+        )
         GuidesStyleMbland.exec_cmd_capture_output(
-          'git config user.name "Test User"', logfile)
+          'git config user.name "Test User"', logfile
+        )
         GuidesStyleMbland.exec_cmd_capture_output(
-          'git commit -m "original repo"', logfile)
+          'git commit -m "original repo"', logfile
+        )
       end
     rescue SystemExit => e
       flunk("Exited with status: #{e.status}\n" \
@@ -120,8 +123,8 @@ GO_SCRIPT
     def test_remove_all_template_files
       write_all_files
       GuidesStyleMbland.remove_template_files repo_dir, outstream
-      assert template_files.none? { |file| File.exist? file }
-      assert nontemplate_files.all? { |file| File.exist? file }
+      assert(template_files.none? { |file| File.exist? file })
+      assert(nontemplate_files.all? { |file| File.exist? file })
     end
   end
 
@@ -130,15 +133,15 @@ GO_SCRIPT
 
     def test_remove_create_repo_command
       write_go_script RepositoryTestHelper::GO_SCRIPT_BEFORE
-      GuidesStyleMbland.delete_create_repo_command_from_go_script(
-        repo_dir, outstream)
+      GuidesStyleMbland.delete_create_repo_command_from_go_script(repo_dir,
+        outstream)
       assert_equal RepositoryTestHelper::GO_SCRIPT_AFTER, read_go_script
     end
 
     def test_create_repo_command_removal_should_be_idemptoent
       write_go_script RepositoryTestHelper::GO_SCRIPT_AFTER
-      GuidesStyleMbland.delete_create_repo_command_from_go_script(
-        repo_dir, outstream)
+      GuidesStyleMbland.delete_create_repo_command_from_go_script(repo_dir,
+        outstream)
       assert_equal RepositoryTestHelper::GO_SCRIPT_AFTER, read_go_script
     end
   end
@@ -153,7 +156,8 @@ GO_SCRIPT
         create_initial_repo logfile
         logfile.puts LOG_TAIL_MARKER
         GuidesStyleMbland.clear_template_files_and_create_new_repository(
-          repo_dir, logfile)
+          repo_dir, logfile
+        )
       end
       assert_expected_final_repository_state log_path
     end
@@ -162,15 +166,15 @@ GO_SCRIPT
       assert_repository_file_system_state
       assert_log_tail_matches_expected log_path
       assert_new_repo_has_nontemplate_files_staged_for_commit
-    rescue
+    rescue StandardError => e
       puts("Log contents: #{File.read(log_path)}")
-      raise
+      raise e
     end
 
     def assert_repository_file_system_state
-      assert template_files.none? { |file| File.exist? file }
-      assert nontemplate_files.all? { |file| File.exist? file }
-      assert_equal GO_SCRIPT_AFTER, read_go_script
+      assert(template_files.none? { |file| File.exist? file })
+      assert(nontemplate_files.all? { |file| File.exist? file })
+      assert_equal(GO_SCRIPT_AFTER, read_go_script)
     end
 
     def assert_log_tail_matches_expected(log_path)
@@ -187,8 +191,9 @@ GO_SCRIPT
       format(LOG_TAIL, Dir.glob(File.realpath(repo_dir)).first)
     end
 
-    LOG_TAIL_MARKER = '*** Clearing template files and creating new repository.'
-    LOG_TAIL = <<LOG_TAIL
+    LOG_TAIL_MARKER = '*** Clearing template files and ' +
+      'creating new repository.'.freeze
+    LOG_TAIL = <<LOG_TAIL.freeze
 Clearing Guides Template files.
 Removing `:create_repo` command from the `./go` script.
 Removing old git repository.
@@ -211,7 +216,7 @@ LOG_TAIL
       assert_equal STAGED_FILES_STATUS, File.read(log_path)
     end
 
-    STAGED_FILES_STATUS = <<STAGED_FILES_STATUS
+    STAGED_FILES_STATUS = <<STAGED_FILES_STATUS.freeze
 A  bar
 A  baz
 A  foo

--- a/test/tags_test.rb
+++ b/test/tags_test.rb
@@ -9,13 +9,13 @@ module GuidesStyleMbland
 
     def setup
       tag_class = ::Liquid::Template.tags[ShouldExpandNavTag::NAME]
-      @should_expand_nav = tag_class.parse(
-        ShouldExpandNavTag::NAME, 'parent_item, nav_parent_url ', nil, nil)
+      @should_expand_nav = tag_class.parse(ShouldExpandNavTag::NAME,
+        'parent_item, nav_parent_url ', nil, nil)
       @context = ::Liquid::Context.new
       context['site'] = {}
       @parent_item = {}
-      context.scopes.push(
-        'parent_item' => parent_item, 'nav_parent_url' => '/foo/')
+      context.scopes.push('parent_item' => parent_item,
+                          'nav_parent_url' => '/foo/')
     end
 
     def test_is_child
@@ -76,8 +76,8 @@ module GuidesStyleMbland
 
     def setup
       tag_class = ::Liquid::Template.tags[PopLastUrlComponent::NAME]
-      @pop_last_url_component = tag_class.parse(
-        PopLastUrlComponent::NAME, ' parent_url ', nil, nil)
+      @pop_last_url_component = tag_class.parse(PopLastUrlComponent::NAME,
+        ' parent_url ', nil, nil)
       @context = ::Liquid::Context.new
     end
 


### PR DESCRIPTION
Note that I could've left the `Layout/IndentHeredoc` enabled by prefixing heredoc tokens with `~` and indenting accordingly, but the Rubocop parser then thought the left shift token (`<<`) was a syntax error. Disabled the rule for now.