### PR TITLE
Ensure flat namespace applies

### DIFF
--- a/_includes/sidebar-children.html
+++ b/_includes/sidebar-children.html
@@ -5,7 +5,7 @@
         aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
 <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}"
     aria-hidden="{% if expand_nav == 'true' %}false{% else %}true{% endif %}">
-  {% for child in parent.children %}
+  {% if site.flat_namespace %}{% assign parent_url = '/' %}{% endif %}{% for child in parent.children %}
   {% capture child_url %}{{ parent_url }}{{ child.url }}{% endcapture %}
     <li class="{% if page.url == child_url %}sidebar-nav-active{% endif %}">
       <a href="{% if child.internal == true %}{{ site.baseurl }}{{ child_url }}{% else %}{{ child.url }}{% endif %}"

--- a/jekyll-theme-guides-mbland.gemspec
+++ b/jekyll-theme-guides-mbland.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'nokogiri'
 end

--- a/lib/jekyll-theme-guides-mbland/breadcrumbs.rb
+++ b/lib/jekyll-theme-guides-mbland/breadcrumbs.rb
@@ -6,7 +6,7 @@ module JekyllThemeGuidesMbland
     def self.generate(site, docs)
       breadcrumbs = create_breadcrumbs(site)
       docs.each do |page|
-        page.data['breadcrumbs'] = breadcrumbs[page.permalink || page.url]
+        page.data['breadcrumbs'] = breadcrumbs[page.data[:working_url]]
       end
     end
 

--- a/lib/jekyll-theme-guides-mbland/generator.rb
+++ b/lib/jekyll-theme-guides-mbland/generator.rb
@@ -10,8 +10,24 @@ module JekyllThemeGuidesMbland
       GeneratedPages.generate_pages_from_navigation_data(site)
       pages = site.collections['pages']
       docs = (pages.nil? ? [] : pages.docs) + site.pages
+      docs.each { |doc| Generator.generate_working_url(doc) }
       Breadcrumbs.generate(site, docs)
       NamespaceFlattener.flatten_url_namespace(site, docs)
+    end
+
+    # Calling the `url` method on a Jekyll::Page or Jekyll::Document will render
+    # the returned value immutable from that point. Here we generate a separate
+    # URL object that we use to calculate `data['permalink']` prior to the first
+    # call to `url`. This enables `NamespaceFlattener.flatten_url_namespace` to
+    # update the URL as a final step, after `Breadcrumbs.generate` has finished
+    # its processing.
+    def self.generate_working_url(doc)
+      t = doc.respond_to?(:url_template) ? doc.url_template : doc.template
+      doc.data[:working_url] = Jekyll::URL.new(
+        template:     t,
+        placeholders: doc.url_placeholders,
+        permalink:    doc.permalink
+      ).to_s
     end
   end
 end

--- a/lib/jekyll-theme-guides-mbland/namespace_flattener.rb
+++ b/lib/jekyll-theme-guides-mbland/namespace_flattener.rb
@@ -11,7 +11,8 @@ module JekyllThemeGuidesMbland
     end
 
     def self.flatten_page_urls(page, flat_to_orig)
-      orig_url = page.permalink || page.url
+      return if page.data['title'].nil?
+      orig_url = page.data[:working_url]
       flattened_url = flat_url(orig_url)
       (flat_to_orig[flattened_url] ||= []) << orig_url
       page.data['permalink'] = flattened_url

--- a/lib/jekyll-theme-guides-mbland/tags.rb
+++ b/lib/jekyll-theme-guides-mbland/tags.rb
@@ -1,4 +1,4 @@
-require 'jekyll/tags/include'
+require 'jekyll'
 require 'liquid'
 
 module JekyllThemeGuidesMbland

--- a/test/breadcrumbs_test.rb
+++ b/test/breadcrumbs_test.rb
@@ -3,14 +3,6 @@ require_relative '../lib/jekyll-theme-guides-mbland/breadcrumbs'
 require 'minitest/autorun'
 
 module JekyllThemeGuidesMbland
-  class DummySite
-    attr_accessor :config
-
-    def initialize
-      @config = {}
-    end
-  end
-
   class BreadcrumbsTest < ::Minitest::Test
     attr_accessor :site
 

--- a/test/dummy_page.rb
+++ b/test/dummy_page.rb
@@ -5,6 +5,7 @@ module JekyllThemeGuidesMbland
     def initialize(site, permalink)
       @site = site
       @data = {}
+      @dir = nil
       data['permalink'] = permalink
     end
 

--- a/test/dummy_page.rb
+++ b/test/dummy_page.rb
@@ -6,6 +6,7 @@ module JekyllThemeGuidesMbland
       @site = site
       @data = {}
       @dir = nil
+      data['title'] = "I'm a dummy!"
       data['permalink'] = permalink
     end
 

--- a/test/flatten_url_namespace_test.rb
+++ b/test/flatten_url_namespace_test.rb
@@ -73,12 +73,12 @@ module JekyllThemeGuidesMbland
       site.collections['pages'] = DummyCollection.new([home_page])
       generator.generate(site)
 
-      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/', home_page.url)
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
 
       site.config['flat_namespace'] = true
-      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/', home_page.url)
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
     end
@@ -87,8 +87,8 @@ module JekyllThemeGuidesMbland
       site.collections['pages'] = DummyCollection.new([home_page, foo_page])
       generator.generate(site)
 
-      assert_equal('/', home_page.data['permalink'])
-      assert_equal('/foo/', foo_page.data['permalink'])
+      assert_equal('/', home_page.url)
+      assert_equal('/foo/', foo_page.url)
 
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
@@ -96,8 +96,8 @@ module JekyllThemeGuidesMbland
         foo_page.data['breadcrumbs'])
 
       site.config['flat_namespace'] = true
-      assert_equal('/', home_page.data['permalink'])
-      assert_equal('/foo/', foo_page.data['permalink'])
+      assert_equal('/', home_page.url)
+      assert_equal('/foo/', foo_page.url)
 
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
@@ -109,13 +109,13 @@ module JekyllThemeGuidesMbland
       site.collections['pages'] = DummyCollection.new(all_docs)
       generator.generate(site)
 
-      assert_equal('/', home_page.data['permalink'])
-      assert_equal('/foo/', foo_page.data['permalink'])
-      assert_equal('/foo/bar/', bar_page.data['permalink'])
-      assert_equal('/foo/baz/', baz_page.data['permalink'])
-      assert_equal('/quux/', quux_page.data['permalink'])
-      assert_equal('/quux/xyzzy/', xyzzy_page.data['permalink'])
-      assert_equal('/quux/xyzzy/plugh/', plugh_page.data['permalink'])
+      assert_equal('/', home_page.url)
+      assert_equal('/foo/', foo_page.url)
+      assert_equal('/foo/bar/', bar_page.url)
+      assert_equal('/foo/baz/', baz_page.url)
+      assert_equal('/quux/', quux_page.url)
+      assert_equal('/quux/xyzzy/', xyzzy_page.url)
+      assert_equal('/quux/xyzzy/plugh/', plugh_page.url)
 
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])
@@ -143,13 +143,13 @@ module JekyllThemeGuidesMbland
       site.collections['pages'] = DummyCollection.new(all_docs)
       generator.generate(site)
 
-      assert_equal('/', home_page.data['permalink'])
-      assert_equal('/foo/', foo_page.data['permalink'])
-      assert_equal('/bar/', bar_page.data['permalink'])
-      assert_equal('/baz/', baz_page.data['permalink'])
-      assert_equal('/quux/', quux_page.data['permalink'])
-      assert_equal('/xyzzy/', xyzzy_page.data['permalink'])
-      assert_equal('/plugh/', plugh_page.data['permalink'])
+      assert_equal('/', home_page.url)
+      assert_equal('/foo/', foo_page.url)
+      assert_equal('/bar/', bar_page.url)
+      assert_equal('/baz/', baz_page.url)
+      assert_equal('/quux/', quux_page.url)
+      assert_equal('/xyzzy/', xyzzy_page.url)
+      assert_equal('/plugh/', plugh_page.url)
 
       assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
         home_page.data['breadcrumbs'])

--- a/test/generated_site_test.rb
+++ b/test/generated_site_test.rb
@@ -1,0 +1,129 @@
+require_relative '../lib/jekyll-theme-guides-mbland/generator'
+require_relative '../lib/jekyll-theme-guides-mbland/tags'
+require_relative './test_site_helper'
+
+require 'jekyll'
+require 'minitest/autorun'
+require 'nokogiri'
+require 'safe_yaml'
+
+module JekyllThemeGuidesMbland
+  # rubocop:disable MethodLength
+  class GeneratedSiteTest < ::Minitest::Test
+    include TestSiteHelper
+
+    DEFAULTS_CONFIG = [
+      'defaults:',
+      '- scope:',
+      '    path: ""',
+      '  values:',
+      '    layout: "default"',
+    ].join("\n")
+
+    def generate_site(extra_config: '')
+      write_config([DEFAULTS_CONFIG, NAV_YAML, extra_config, ''].join("\n"))
+      copy_pages(ALL_PAGES)
+      config = SafeYAML.load(File.read(config_path))
+      config['source'] = testdir
+      config['destination'] = site_dir
+      config['theme'] = 'jekyll-theme-guides-mbland'
+      site = Jekyll::Site.new(Jekyll::Configuration.from(config))
+      orig_verbosity = $VERBOSE
+      $VERBOSE = nil
+      site.process
+      $VERBOSE = orig_verbosity
+    end
+
+    def generated_files
+      Dir.glob(File.join(site_dir, '**', '*'))
+         .select { |f| f.match?(%r{/index\.html$}) }
+         .map { |f| f.sub(%r{^#{site_dir}/}, '').sub(%r{/index\.html$}, '') }
+         .sort
+    end
+
+    def parse_page(page_name)
+      Nokogiri::HTML(File.read(File.join(site_dir, page_name, 'index.html')))
+    end
+
+    def breadcrumbs(page)
+      page.xpath('//div[@class = "breadcrumbs"]//li')
+    end
+
+    def breadcrumbs_text(page)
+      breadcrumbs(page).map(&:text)
+    end
+
+    def breadcrumbs_hrefs(page)
+      breadcrumbs(page).xpath('.//a').map { |bc| bc['href'] }
+    end
+
+    def nav_hrefs(page)
+      page.xpath('//nav//a').map { |a| a['href'] }.sort
+    end
+
+    DEFAULT_SITE_PATHS = %w[
+      add-a-new-page
+      add-a-new-page/make-a-child-page
+      add-images
+      github-setup
+      index.html
+      post-your-guide
+      update-the-config-file
+      update-the-config-file/understanding-baseurl
+    ].sort.freeze
+
+    DEFAULT_SITE_URLS = %w[
+      /
+      /add-a-new-page/
+      /add-a-new-page/make-a-child-page/
+      /add-images/
+      /github-setup/
+      /post-your-guide/
+      /update-the-config-file/
+      /update-the-config-file/understanding-baseurl/
+    ].sort.freeze
+
+    def test_generated_site
+      generate_site
+      assert_equal(DEFAULT_SITE_PATHS, generated_files)
+      page = parse_page(File.join('add-a-new-page', 'make-a-child-page'))
+      assert_equal(['Add a new page', 'Make a child page'],
+        breadcrumbs_text(page))
+      assert_equal(['/add-a-new-page/'], breadcrumbs_hrefs(page))
+      assert_equal(DEFAULT_SITE_URLS, nav_hrefs(page))
+    end
+
+    FLAT_SITE_PATHS = %w[
+      add-a-new-page
+      make-a-child-page
+      add-images
+      github-setup
+      index.html
+      post-your-guide
+      update-the-config-file
+      understanding-baseurl
+    ].sort.freeze
+
+    FLAT_SITE_URLS = %w[
+      /
+      /add-a-new-page/
+      /make-a-child-page/
+      /add-images/
+      /github-setup/
+      /post-your-guide/
+      /update-the-config-file/
+      /understanding-baseurl/
+    ].sort.freeze
+
+    def test_generated_site_with_flat_namespace_enabled
+      generate_site(extra_config: 'flat_namespace: true')
+      assert_equal(FLAT_SITE_PATHS, generated_files)
+      page = parse_page('make-a-child-page')
+      assert_equal(['Add a new page', 'Make a child page'],
+        breadcrumbs_text(page))
+      assert_equal(['/add-a-new-page/'], breadcrumbs_hrefs(page))
+      assert_equal(FLAT_SITE_URLS, nav_hrefs(page))
+    end
+  end
+  # rubocop:enable MethodLength
+end

--- a/test/test_site_helper.rb
+++ b/test/test_site_helper.rb
@@ -4,7 +4,7 @@ require 'stringio'
 
 module JekyllThemeGuidesMbland
   module TestSiteHelper
-    attr_reader :testdir, :config_path, :pages_dir
+    attr_reader :testdir, :config_path, :pages_dir, :site_dir
 
     TEST_DIR = File.dirname(__FILE__)
     TEST_PAGES_DIR = File.join(TEST_DIR, '_pages')
@@ -43,6 +43,7 @@ module JekyllThemeGuidesMbland
       @config_path = File.join(testdir, '_config.yml')
       @pages_dir = File.join(testdir, '_pages')
       FileUtils.mkdir_p(pages_dir)
+      @site_dir = File.join(testdir, '_site')
     end
 
     def teardown

--- a/test/test_site_helper.rb
+++ b/test/test_site_helper.rb
@@ -1,0 +1,118 @@
+require 'fileutils'
+require 'safe_yaml'
+require 'stringio'
+
+module JekyllThemeGuidesMbland
+  module TestSiteHelper
+    attr_reader :testdir, :config_path, :pages_dir
+
+    TEST_DIR = File.dirname(__FILE__)
+    TEST_PAGES_DIR = File.join(TEST_DIR, '_pages')
+
+    NAV_DATA_PATH = File.join(TEST_DIR, 'navigation_test_data.yml')
+    NAV_YAML = File.read(NAV_DATA_PATH)
+    NAV_DATA = SafeYAML.load(NAV_YAML, safe: true)
+
+    COLLECTIONS_CONFIG = [
+      'collections:',
+      '  pages:',
+      '    output: true',
+      '    permalink: /:path/',
+      '',
+    ].join("\n")
+
+    ALL_PAGES = %w[
+      add-a-new-page/make-a-child-page.md
+      add-a-new-page.md
+      add-images.md
+      github-setup.md
+      index.md
+      post-your-guide.md
+      update-the-config-file/understanding-baseurl.md
+      update-the-config-file.md
+    ].freeze
+
+    LEADING_COMMENT  = '# Comments before the navigation section ' +
+      'should be preserved.'.freeze
+    TRAILING_COMMENT = '# Comments after the navigation section ' +
+      "should also be preserved.\n".freeze
+
+    def setup
+      @assertions = 0
+      @testdir = Dir.glob(Dir.mktmpdir).first
+      @config_path = File.join(testdir, '_config.yml')
+      @pages_dir = File.join(testdir, '_pages')
+      FileUtils.mkdir_p(pages_dir)
+    end
+
+    def teardown
+      FileUtils.rm_rf(testdir, secure: true)
+    end
+
+    def write_config(config_data, with_collections: true)
+      prefix = with_collections ? "#{COLLECTIONS_CONFIG}\n" : ''
+      File.write(config_path, "#{prefix}#{config_data}")
+    end
+
+    def read_config
+      File.read(config_path)
+    end
+
+    def write_page(filename, content)
+      File.write(File.join(pages_dir, filename), content)
+    end
+
+    def copy_pages(pages)
+      pages.each do |page|
+        parent_dir = File.dirname(page)
+        full_orig_path = File.join(TEST_PAGES_DIR, page)
+        target_dir = File.join(pages_dir, parent_dir)
+        FileUtils.mkdir_p(target_dir)
+        FileUtils.cp(full_orig_path, target_dir)
+      end
+    end
+
+    def nav_array_to_hash(nav)
+      (nav['navigation'] || []).map { |i| [i['text'], i] }.to_h
+    end
+
+    def assert_result_matches_expected_config(nav_data)
+      # We can't do a straight string comparison, since the items may not be
+      # in order relative to the original.
+      result = read_config
+      result_data = SafeYAML.load(result, safe: true)
+      refute_equal(-1, result.index(LEADING_COMMENT),
+        'Comment before `navigation:` section is missing')
+      refute_equal(-1, result.index(TRAILING_COMMENT),
+        'Comment after `navigation:` section is missing')
+      assert_equal(nav_array_to_hash(nav_data), nav_array_to_hash(result_data))
+    end
+
+    # We need to be careful not to modify the original NAV_DATA object when
+    # sorting.
+    def sorted_nav_data(nav_data)
+      nav_data = {}.merge(nav_data)
+      sorted = nav_data['navigation'].map { |i| i }.sort_by { |i| i['text'] }
+      nav_data['navigation'] = sorted
+      nav_data
+    end
+
+    def nav_config(*lines)
+      [
+        COLLECTIONS_CONFIG,
+        LEADING_COMMENT,
+        'navigation:',
+        *lines,
+        TRAILING_COMMENT,
+      ].join("\n")
+    end
+
+    def capture_stderr
+      orig_stderr = $stderr
+      $stderr = StringIO.new
+      yield
+    ensure
+      $stderr = orig_stderr
+    end
+  end
+end

--- a/test/test_site_helper.rb
+++ b/test/test_site_helper.rb
@@ -19,7 +19,7 @@ module JekyllThemeGuidesMbland
       '    output: true',
       '    permalink: /:path/',
       '',
-    ].join("\n")
+    ].join("\n").freeze
 
     ALL_PAGES = %w[
       add-a-new-page/make-a-child-page.md


### PR DESCRIPTION
The plugin now successfully generates a site with a flat namespace as expected.

Two things: When Document.url or Page.url is called, that freezes the value. So we use WorkingUrl to create a URL value that we can work with long before one of those other methods gets called, so we can set the permalink before then.

Second: The sidebar was always getting generated as if the namespace was always hierarchical. Now we leave out the parent link prefix while generating `_includes/sidebar-children.html` when `flat_namespace:` is set to true in the config.

`test/tags_test.rb` now requires the top-level `jekyll` module to fix an error whereby running it standalone via `bundle exec rake test TEST=test/tags_test.rb` would result in `jekyll/tags/include` raising an uninitialized constant error.