### PR TITLE
breadcrumbs: Fix style to align with title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,8 +18,8 @@
           {% jekyll_pages_api_search_interface %}{% if site.back_link %}
 
           <div class="back-link"><a href="{{ site.back_link.url }}">&laquo; {{ site.back_link.text }}</a></div>{% endif %}
+          {% include breadcrumbs.html %}
         </div>
-        {% include breadcrumbs.html %}
       </header>
 
       <div class="wrap content">

--- a/_sass/_jekyll-theme-guides-mbland-main.scss
+++ b/_sass/_jekyll-theme-guides-mbland-main.scss
@@ -173,10 +173,11 @@ Navigation
 
 .breadcrumbs ol {
   list-style: none;
-  padding-left: 20px;
   margin: 0px;
   display: inline-block;
   font-size: 14px;
+  -webkit-padding-start: 0px;
+  -moz-padding-start: 0px;
 }
 
 .breadcrumbs ol li {
@@ -367,6 +368,11 @@ header div.wrap div.back-link a{
 }
 
 header div.wrap div.back-link a:hover{ text-decoration: none; }
+
+header div.wrap div.breadcrumbs{
+    position: absolute;
+    bottom: -1em;
+}
 
 @media screen and (min-width: 45em){
     header h1.site-title{


### PR DESCRIPTION
This required overriding WebKit and Mozilla properties built into Chrome, Firefox, and Safari.