### PR TITLE
search: Hide widget, script loading when disabled

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,5 +2,5 @@
 <script src="{{ site.baseurl }}/assets/js/accordion.js"></script>
 <script src="{{ site.baseurl }}/assets/js/guide.js"></script>{% for script in site.scripts %}
 <script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}{% for script in page.scripts %}
-<script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}
-{% jekyll_pages_api_search_load %}
+<script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}{% unless site.jekyll_pages_api_search.skip_index %}
+{% jekyll_pages_api_search_load %}{% endunless %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
 
           <h1 class="site-title"><a class="title-link" href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
 
-          {% jekyll_pages_api_search_interface %}{% if site.back_link %}
+          {% unless site.jekyll_pages_api_search.skip_index %}{% jekyll_pages_api_search_interface %}{% endunless %}{% if site.back_link %}
 
           <div class="back-link"><a href="{{ site.back_link.url }}">&laquo; {{ site.back_link.text }}</a></div>{% endif %}
           {% include breadcrumbs.html %}


### PR DESCRIPTION
It's rather unintuitive to have a search box on a page when there's no search, or to try to load a search index that doesn't exist.