### PR TITLE
Fix #13: Table of contents "children:" entries inherit sibling's external URL hostname

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
     - 'Rakefile'
     - 'jekyll-theme-guides-mbland.gemspec'
     - 'lib/jekyll-theme-guides-mbland.rb'
+    - 'lib/jekyll-theme-guides-mbland/*.rb'
+    - 'test/*.rb'
 
 Lint/ParenthesesAsGroupedExpression:
   Description: Checks for method calls with a space before the opening parenthesis.
@@ -83,10 +85,16 @@ Style/StringLiterals:
   - single_quotes
   - double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description:
-    Not allowing a comma after the last item in a list or hash when each item
-    is on a single line is a bug, not a feature.
+    Not allowing a comma after the last item in a list when each item is on a
+    single line is a bug, not a feature.
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  Description:
+    Not allowing a comma after the last item in a hash when each item is on a
+    single line is a bug, not a feature.
   EnforcedStyleForMultiline: comma
 
 Layout/AlignParameters:

--- a/_includes/sidebar-children.html
+++ b/_includes/sidebar-children.html
@@ -6,12 +6,12 @@
 <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}"
     aria-hidden="{% if expand_nav == 'true' %}false{% else %}true{% endif %}">
   {% if site.flat_namespace %}{% assign parent_url = '/' %}{% endif %}{% for child in parent.children %}
-  {% capture child_url %}{{ parent_url }}{{ child.url }}{% endcapture %}
+  {% capture child_url %}{% if child.internal == true %}{{ parent_url }}{% endif %}{{ child.url }}{% endcapture %}
     <li class="{% if page.url == child_url %}sidebar-nav-active{% endif %}">
       <a href="{% if child.internal == true %}{{ site.baseurl }}{{ child_url }}{% else %}{{ child.url }}{% endif %}"
         title="{% if page.url == child_url %}Current Page{% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
-      {% assign parent = child %}{% assign parent_url = child_url %}
+      {% if child.children %}{% assign parent = child %}{% assign parent_url = child_url %}
       {% include sidebar-children.html %}
-      {% capture parent_url %}{% jekyll_theme_guides_mbland_pop_last_url_component parent_url %}{% endcapture %}
+      {% capture parent_url %}{% jekyll_theme_guides_mbland_pop_last_url_component parent_url %}{% endcapture %}{% endif %}
     </li>{% endfor %}
 </ul>{% endif %}

--- a/jekyll-theme-guides-mbland.gemspec
+++ b/jekyll-theme-guides-mbland.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jekyll-theme-guides-mbland/version'
 

--- a/jekyll-theme-guides-mbland.gemspec
+++ b/jekyll-theme-guides-mbland.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __dir__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jekyll-theme-guides-mbland/version'
 

--- a/lib/jekyll-theme-guides-mbland/navigation.rb
+++ b/lib/jekyll-theme-guides-mbland/navigation.rb
@@ -229,7 +229,7 @@ module JekyllThemeGuidesMbland
     def self.write_navigation_data_to_config_file(config_path, nav_data)
       lines = []
       in_navigation = false
-      open(config_path).each_line do |line|
+      File.open(config_path).each_line do |line|
         in_navigation = process_line line, lines, nav_data, in_navigation
       end
       File.write config_path, lines.join

--- a/lib/jekyll-theme-guides-mbland/tags.rb
+++ b/lib/jekyll-theme-guides-mbland/tags.rb
@@ -8,7 +8,7 @@ module JekyllThemeGuidesMbland
 
     attr_reader :parent_reference, :url_reference
 
-    def initialize(_tag_name, markup, _)
+    def initialize(_tag_name, markup, _tokens)
       references = markup.split(',').map(&:strip)
       @parent_reference = references.shift
       @url_reference = references.shift
@@ -37,7 +37,7 @@ module JekyllThemeGuidesMbland
 
     attr_reader :reference
 
-    def initialize(_tag_name, markup, _)
+    def initialize(_tag_name, markup, _tokens)
       @reference = markup.strip
     end
 

--- a/test/generated_site_test.rb
+++ b/test/generated_site_test.rb
@@ -8,6 +8,7 @@ require 'nokogiri'
 require 'safe_yaml'
 
 module JekyllThemeGuidesMbland
+  # rubocop:disable ClassLength
   # rubocop:disable MethodLength
   class GeneratedSiteTest < ::Minitest::Test
     include TestSiteHelper
@@ -153,5 +154,6 @@ module JekyllThemeGuidesMbland
         nav_hrefs(page))
     end
     # rubocop:enable MethodLength
+    # rubocop:enable ClassLength
   end
 end

--- a/test/generated_site_test.rb
+++ b/test/generated_site_test.rb
@@ -20,8 +20,8 @@ module JekyllThemeGuidesMbland
       '    layout: "default"',
     ].join("\n")
 
-    def generate_site(extra_config: '')
-      write_config([DEFAULTS_CONFIG, NAV_YAML, extra_config, ''].join("\n"))
+    def generate_site(nav_data: NAV_YAML, extra_config: '')
+      write_config([DEFAULTS_CONFIG, nav_data, extra_config, ''].join("\n"))
       copy_pages(ALL_PAGES)
       config = SafeYAML.load(File.read(config_path))
       config['source'] = testdir
@@ -124,6 +124,34 @@ module JekyllThemeGuidesMbland
       assert_equal(['/add-a-new-page/'], breadcrumbs_hrefs(page))
       assert_equal(FLAT_SITE_URLS, nav_hrefs(page))
     end
+
+    NAV_CONFIG_WITH_EXTERNAL_SIBLING = [
+      'navigation:',
+      '- text: Parent',
+      '  url: parent/',
+      '  internal: true',
+      '  children:',
+      '  - text: External',
+      '    url: https://external.example.org/foo',
+      '    internal: false',
+      '  - text: Child',
+      '    url: child/',
+      '    internal: true',
+    ].freeze
+
+    EXPECTED_CONFIG_WITH_EXTERNAL_SIBLING_NAV_URLS = [
+      '/parent/',
+      '/parent/child/',
+      'https://external.example.org/foo',
+    ].freeze
+
+    # Regression test for #13.
+    def test_internal_child_does_not_inherit_siblings_external_url
+      generate_site(nav_data: NAV_CONFIG_WITH_EXTERNAL_SIBLING)
+      page = parse_page('')
+      assert_equal(EXPECTED_CONFIG_WITH_EXTERNAL_SIBLING_NAV_URLS,
+        nav_hrefs(page))
+    end
+    # rubocop:enable MethodLength
   end
-  # rubocop:enable MethodLength
 end

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -129,6 +129,33 @@ module JekyllThemeGuidesMbland
       assert_result_matches_expected_config(expected_data)
     end
 
+    CONFIG_WITH_EXTERNAL_PAGE_THAT_HAS_CHILDREN = [
+      '- text: Parent',
+      '  url: parent/',
+      '  internal: true',
+      '  children:',
+      '  - text: External URL',
+      '    url: https://github.com/mbland/guides-style-mbland',
+      '    internal: false',
+      '    children:',
+      '    - text: Should not be allowed',
+      '      url: external-child/',
+      '      internal: true',
+    ].freeze
+
+    def test_external_pages_cannot_have_children
+      capture_stderr do
+        write_config(nav_config(CONFIG_WITH_EXTERNAL_PAGE_THAT_HAS_CHILDREN))
+        exception = assert_raises(SystemExit) do
+          JekyllThemeGuidesMbland.update_navigation_configuration(testdir)
+        end
+        assert_equal(1, exception.status)
+        assert_equal("Existing navigation entries contain errors:\n" \
+          "  External URL: external navigation URLs cannot have children\n" \
+          "_config.yml not updated\n", $stderr.string)
+      end
+    end
+
     CONFIG_WITH_MISSING_PAGES = [
       '- text: Introduction',
       '  internal: true',


### PR DESCRIPTION
Closes #13. Reproduced the problem in a test, then fixed it in `_includes/sidebar-children.html`. As an extra precaution, I added logic to `lib/jekyll-theme-guides-mbland/navigation.rb` to ensure that external URL nodes can't contain `children:`.

Also updates the Rubocop config and cleans up the resulting warnings.

Once I've merged and deployed this, I'll update our Cvent-internal style gem.

cc: @paragbhagwat